### PR TITLE
setmode: forbid calling without argument #2

### DIFF
--- a/lfs_ffi.lua
+++ b/lfs_ffi.lua
@@ -314,7 +314,7 @@ if OS == "Windows" then
         if io.type(file) ~= 'file' then
             error("setmode: invalid file")
         end
-        if mode ~= nil and (mode ~= 'text' and mode ~= 'binary') then
+        if mode ~= 'text' and mode ~= 'binary' then
             error('setmode: invalid mode')
         end
         mode = (mode == 'text') and 0x4000 or 0x8000

--- a/lfs_spec.lua
+++ b/lfs_spec.lua
@@ -153,6 +153,10 @@ describe('lfs', function()
                 has_error(function() lfs.setmode(fh, 'bin') end, 'setmode: invalid mode')
             end)
 
+            it('setmode incorrect mode', function()
+                has_error(function() lfs.setmode(fh) end, 'setmode: invalid mode')
+            end)
+
             it('setmode incorrect file', function()
                 has_error(function() lfs.setmode('file', 'binary') end, 'setmode: invalid file')
             end)


### PR DESCRIPTION
Before this patch that was equivalent to calling with 'binary'.
Now the behavior corresponds to upstream.

Not sure if we should bother of exact error messages.
The original are like these:
```
bad argument #2 to '?' (string expected, got no value)
bad argument #2 to '?' (string expected, got nil)
bad argument #2 to '?' (invalid option 'abracadabra')
```